### PR TITLE
feat: add +/− step buttons to all numeric inputs

### DIFF
--- a/src/components/MortgageForm.jsx
+++ b/src/components/MortgageForm.jsx
@@ -2,8 +2,56 @@
 import React, { useState } from 'react'
 import { CalculatorIcon } from 'lucide-react'
 
-const inputClass = 'w-full border border-slate-300 rounded-lg px-3 py-2 text-sm text-slate-800 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition'
 const labelClass = 'text-sm font-semibold text-slate-600 uppercase tracking-wide'
+
+function StepInput({ id, name, rawValue, displayValue, step, onChange, onFocus, onBlur, inputMode, placeholder }) {
+  function doStep(delta) {
+    const current = parseFloat(rawValue) || 0
+    // Determine decimal places from step to avoid floating-point drift
+    const decimals = step.toString().includes('.') ? step.toString().split('.')[1].length : 0
+    const factor = Math.pow(10, decimals)
+    const next = Math.max(0, Math.round((current + delta) * factor) / factor)
+    onChange({ target: { name, value: String(next) } })
+  }
+
+  const btnClass =
+    'px-3 py-2 bg-slate-50 hover:bg-slate-100 active:bg-slate-200 text-slate-600 text-base font-bold transition-colors select-none'
+
+  return (
+    <div className="flex w-full rounded-lg border border-slate-300 focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-transparent overflow-hidden">
+      <button
+        type="button"
+        onClick={() => doStep(-step)}
+        className={`${btnClass} border-r border-slate-300`}
+        tabIndex={-1}
+        aria-label={`Decrease ${id}`}
+      >
+        −
+      </button>
+      <input
+        id={id}
+        className="flex-1 min-w-0 px-3 py-2 text-sm text-slate-800 bg-white focus:outline-none text-center"
+        type="text"
+        name={name}
+        placeholder={placeholder}
+        value={displayValue}
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        inputMode={inputMode}
+      />
+      <button
+        type="button"
+        onClick={() => doStep(step)}
+        className={`${btnClass} border-l border-slate-300`}
+        tabIndex={-1}
+        aria-label={`Increase ${id}`}
+      >
+        +
+      </button>
+    </div>
+  )
+}
 
 export default function MortgageForm({ inputs, onChange, onCalculate, expanded, setExpanded }) {
   const [focusedField, setFocusedField] = useState(null)
@@ -19,15 +67,19 @@ export default function MortgageForm({ inputs, onChange, onCalculate, expanded, 
     return raw ? `${raw}%` : ''
   }
 
+  function focus(name) { return () => setFocusedField(name) }
+  function blur()      { return () => setFocusedField(null) }
+
   if (!expanded) return null
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+      {/* ── Left column ── */}
       <div className="flex flex-col gap-3">
         <label htmlFor="address" className={labelClass}>Address</label>
         <input
           id="address"
-          className={inputClass}
+          className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm text-slate-800 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
           type="text"
           name="address"
           placeholder="Address"
@@ -36,134 +88,100 @@ export default function MortgageForm({ inputs, onChange, onCalculate, expanded, 
         />
 
         <label htmlFor="listPrice" className={labelClass}>List Price</label>
-        <input
-          id="listPrice"
-          className={inputClass}
-          type="text"
-          name="listPrice"
-          placeholder="$0"
-          value={displayCurrency(inputs.listPrice, 'listPrice')}
+        <StepInput
+          id="listPrice" name="listPrice" step={1000}
+          rawValue={inputs.listPrice}
+          displayValue={displayCurrency(inputs.listPrice, 'listPrice')}
           onChange={onChange}
-          onFocus={() => setFocusedField('listPrice')}
-          onBlur={() => setFocusedField(null)}
-          inputMode="numeric"
+          onFocus={focus('listPrice')} onBlur={blur()}
+          inputMode="numeric" placeholder="$0"
         />
 
         <label htmlFor="offerPrice" className={labelClass}>Offer Price</label>
-        <input
-          id="offerPrice"
-          className={inputClass}
-          type="text"
-          name="offerPrice"
-          placeholder="$0"
-          value={displayCurrency(inputs.offerPrice, 'offerPrice')}
+        <StepInput
+          id="offerPrice" name="offerPrice" step={1000}
+          rawValue={inputs.offerPrice}
+          displayValue={displayCurrency(inputs.offerPrice, 'offerPrice')}
           onChange={onChange}
-          onFocus={() => setFocusedField('offerPrice')}
-          onBlur={() => setFocusedField(null)}
-          inputMode="numeric"
+          onFocus={focus('offerPrice')} onBlur={blur()}
+          inputMode="numeric" placeholder="$0"
         />
 
         <label htmlFor="downPaymentPct" className={labelClass}>Down Payment</label>
-        <input
-          id="downPaymentPct"
-          className={inputClass}
-          type="text"
-          name="downPaymentPct"
-          placeholder="0%"
-          value={displayPercent(inputs.downPaymentPct, 'downPaymentPct')}
+        <StepInput
+          id="downPaymentPct" name="downPaymentPct" step={1}
+          rawValue={inputs.downPaymentPct}
+          displayValue={displayPercent(inputs.downPaymentPct, 'downPaymentPct')}
           onChange={onChange}
-          onFocus={() => setFocusedField('downPaymentPct')}
-          onBlur={() => setFocusedField(null)}
-          inputMode="decimal"
+          onFocus={focus('downPaymentPct')} onBlur={blur()}
+          inputMode="decimal" placeholder="0%"
         />
 
         <label htmlFor="interestRatePct" className={labelClass}>Interest Rate</label>
-        <input
-          id="interestRatePct"
-          className={inputClass}
-          type="text"
-          name="interestRatePct"
-          placeholder="0%"
-          value={displayPercent(inputs.interestRatePct, 'interestRatePct')}
+        <StepInput
+          id="interestRatePct" name="interestRatePct" step={0.125}
+          rawValue={inputs.interestRatePct}
+          displayValue={displayPercent(inputs.interestRatePct, 'interestRatePct')}
           onChange={onChange}
-          onFocus={() => setFocusedField('interestRatePct')}
-          onBlur={() => setFocusedField(null)}
-          inputMode="decimal"
+          onFocus={focus('interestRatePct')} onBlur={blur()}
+          inputMode="decimal" placeholder="0%"
         />
       </div>
 
+      {/* ── Right column ── */}
       <div className="flex flex-col gap-3">
         <label htmlFor="taxes" className={labelClass}>Annual Property Taxes</label>
-        <input
-          id="taxes"
-          className={inputClass}
-          type="text"
-          name="taxes"
-          placeholder="$0"
-          value={displayCurrency(inputs.taxes, 'taxes')}
+        <StepInput
+          id="taxes" name="taxes" step={500}
+          rawValue={inputs.taxes}
+          displayValue={displayCurrency(inputs.taxes, 'taxes')}
           onChange={onChange}
-          onFocus={() => setFocusedField('taxes')}
-          onBlur={() => setFocusedField(null)}
-          inputMode="numeric"
+          onFocus={focus('taxes')} onBlur={blur()}
+          inputMode="numeric" placeholder="$0"
         />
 
         <label htmlFor="insurance" className={labelClass}>Annual Home Insurance</label>
-        <input
-          id="insurance"
-          className={inputClass}
-          type="text"
-          name="insurance"
-          placeholder="$0"
-          value={displayCurrency(inputs.insurance, 'insurance')}
+        <StepInput
+          id="insurance" name="insurance" step={100}
+          rawValue={inputs.insurance}
+          displayValue={displayCurrency(inputs.insurance, 'insurance')}
           onChange={onChange}
-          onFocus={() => setFocusedField('insurance')}
-          onBlur={() => setFocusedField(null)}
-          inputMode="numeric"
+          onFocus={focus('insurance')} onBlur={blur()}
+          inputMode="numeric" placeholder="$0"
         />
 
         <label htmlFor="grossMonthlyIncome" className={labelClass}>Gross Monthly Income</label>
-        <input
-          id="grossMonthlyIncome"
-          className={inputClass}
-          type="text"
-          name="grossMonthlyIncome"
-          placeholder="$0"
-          value={displayCurrency(inputs.grossMonthlyIncome, 'grossMonthlyIncome')}
+        <StepInput
+          id="grossMonthlyIncome" name="grossMonthlyIncome" step={500}
+          rawValue={inputs.grossMonthlyIncome}
+          displayValue={displayCurrency(inputs.grossMonthlyIncome, 'grossMonthlyIncome')}
           onChange={onChange}
-          onFocus={() => setFocusedField('grossMonthlyIncome')}
-          onBlur={() => setFocusedField(null)}
-          inputMode="numeric"
+          onFocus={focus('grossMonthlyIncome')} onBlur={blur()}
+          inputMode="numeric" placeholder="$0"
         />
 
         <label htmlFor="netMonthlyIncome" className={labelClass}>Net Monthly Income</label>
-        <input
-          id="netMonthlyIncome"
-          className={inputClass}
-          type="text"
-          name="netMonthlyIncome"
-          placeholder="$0"
-          value={displayCurrency(inputs.netMonthlyIncome, 'netMonthlyIncome')}
+        <StepInput
+          id="netMonthlyIncome" name="netMonthlyIncome" step={500}
+          rawValue={inputs.netMonthlyIncome}
+          displayValue={displayCurrency(inputs.netMonthlyIncome, 'netMonthlyIncome')}
           onChange={onChange}
-          onFocus={() => setFocusedField('netMonthlyIncome')}
-          onBlur={() => setFocusedField(null)}
-          inputMode="numeric"
+          onFocus={focus('netMonthlyIncome')} onBlur={blur()}
+          inputMode="numeric" placeholder="$0"
         />
 
         <label htmlFor="monthlyExpenses" className={labelClass}>Monthly Expenses</label>
-        <input
-          id="monthlyExpenses"
-          className={inputClass}
-          type="text"
-          name="monthlyExpenses"
-          placeholder="$0"
-          value={displayCurrency(inputs.monthlyExpenses, 'monthlyExpenses')}
+        <StepInput
+          id="monthlyExpenses" name="monthlyExpenses" step={100}
+          rawValue={inputs.monthlyExpenses}
+          displayValue={displayCurrency(inputs.monthlyExpenses, 'monthlyExpenses')}
           onChange={onChange}
-          onFocus={() => setFocusedField('monthlyExpenses')}
-          onBlur={() => setFocusedField(null)}
-          inputMode="numeric"
+          onFocus={focus('monthlyExpenses')} onBlur={blur()}
+          inputMode="numeric" placeholder="$0"
         />
       </div>
 
+      {/* ── Calculate button ── */}
       <div className="sm:col-span-2 flex justify-center mt-2">
         <button
           className="px-6 py-2.5 rounded-lg bg-blue-600 text-white text-sm font-semibold hover:bg-blue-700 transition-colors shadow-sm flex items-center gap-2"


### PR DESCRIPTION
## Summary
- Wraps every numeric field in a `StepInput` control: `[−]` · input · `[+]` rendered as one cohesive unit
- Focus ring (blue) appears on the whole control via `focus-within`
- Manual typing still works: focus shows the raw number, blur shows the formatted value (currency / percent)
- Step buttons clamp at 0 and use precise decimal rounding to avoid floating-point drift (important for 0.125% interest steps)

## Step sizes
| Field | Step |
|---|---|
| List Price / Offer Price | $1,000 |
| Down Payment | 1% |
| Interest Rate | 0.125% |
| Annual Taxes | $500 |
| Annual Insurance | $100 |
| Gross / Net Monthly Income | $500 |
| Monthly Expenses | $100 |

## Test plan
- [ ] Click `+` on List Price → value increases by $1,000 and displays formatted
- [ ] Click `−` on Interest Rate → decreases by 0.125% (no floating-point noise, e.g. 3.5 → 3.375, not 3.3750000001)
- [ ] Click `−` when value is 0 → stays at 0 (no negatives)
- [ ] Click into any field → shows raw number; type a new value; tab out → shows formatted
- [ ] Focus ring wraps the entire `[−] input [+]` control, not just the input
- [ ] Mobile: controls stack and are large enough to tap comfortably

🤖 Generated with [Claude Code](https://claude.com/claude-code)