### PR TITLE
cleanup: remove list price field, update tab title and favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Mortgage Calculator</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#2563eb">
+  <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ import LoanTaxTable from './components/LoanTaxTable'
 import { PencilIcon } from 'lucide-react'
 
 const CURRENCY_FIELDS = new Set([
-  'listPrice', 'offerPrice', 'taxes', 'insurance',
+  'offerPrice', 'taxes', 'insurance',
   'grossMonthlyIncome', 'netMonthlyIncome', 'monthlyExpenses',
 ])
 const PERCENT_FIELDS = new Set(['downPaymentPct', 'interestRatePct'])
@@ -15,7 +15,6 @@ const PERCENT_FIELDS = new Set(['downPaymentPct', 'interestRatePct'])
 function App() {
   const [inputs, setInputs] = useState({
     address: '123 Main St',
-    listPrice: '339000',
     offerPrice: '339000',
     downPaymentPct: '20',
     interestRatePct: '3.5',

--- a/src/components/MortgageForm.jsx
+++ b/src/components/MortgageForm.jsx
@@ -87,16 +87,6 @@ export default function MortgageForm({ inputs, onChange, onCalculate, expanded, 
           onChange={onChange}
         />
 
-        <label htmlFor="listPrice" className={labelClass}>List Price</label>
-        <StepInput
-          id="listPrice" name="listPrice" step={1000}
-          rawValue={inputs.listPrice}
-          displayValue={displayCurrency(inputs.listPrice, 'listPrice')}
-          onChange={onChange}
-          onFocus={focus('listPrice')} onBlur={blur()}
-          inputMode="numeric" placeholder="$0"
-        />
-
         <label htmlFor="offerPrice" className={labelClass}>Offer Price</label>
         <StepInput
           id="offerPrice" name="offerPrice" step={1000}


### PR DESCRIPTION
## Summary
- Remove unused **List Price** input from form and state
- Rename browser tab from "Vite + React" → **Mortgage Calculator**
- Replace Vite logo favicon with a relevant house SVG icon

## Test plan
- [ ] Verify List Price field no longer appears in the form
- [ ] Confirm tab title reads "Mortgage Calculator" in browser
- [ ] Confirm house favicon appears in the browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)